### PR TITLE
Enable the use of DIV instead of textarea

### DIFF
--- a/src/wysihtml-editor.component.html
+++ b/src/wysihtml-editor.component.html
@@ -1,2 +1,5 @@
-<textarea [style.width.px]="width" [style.height.px]="height" placeholder="{{placeholder}}" class="wysihtml5-container" contenteditable="true" #wysihtml>
+<textarea *ngIf="type == 'textarea'" [style.width.px]="width" [style.height.px]="height" [style.maxWidth.px]="maxWidth" [style.maxHeight.px]="maxHeight" placeholder="{{placeholder}}" class="wysihtml5-container" contenteditable="true" #wysihtml>
 </textarea>
+
+<div *ngIf="type != 'textarea'" [style.minWidth.px]="width" [style.minHeight.px]="height" [style.maxWidth.px]="maxWidth" [style.maxHeight.px]="maxHeight" [attr.data-placeholder]="placeholder" class="wysihtml5-container" contenteditable="true" #wysihtml>
+</div>

--- a/src/wysihtml-editor.component.ts
+++ b/src/wysihtml-editor.component.ts
@@ -23,6 +23,11 @@ export class WysiHtmlEditorComponent implements OnDestroy {
   @Input('width') width = 300;
   @Input('height') height = 150;
 
+  @Input('maxWidth') maxWidth;
+  @Input('maxHeight') maxHeight;
+
+  @Input('type') type: string = 'div';
+
   private _initialValue : string;
 
   /**


### PR DESCRIPTION
When trying to use the element, the textarea works great but it doesn't auto expand as you edit your content.

This enables the use of the div element by default, which works great and doesn't generate an iframe workaround that happened in the past, but allows the setting (type="textarea") to force it.